### PR TITLE
Perf: Find inefficiencies

### DIFF
--- a/confirmed-native-extra.ts
+++ b/confirmed-native-extra.ts
@@ -35,15 +35,15 @@ const accountTxListResultSchema = z.array(
 export const runConfirmedNativeTokenExtraWorker = async (): Promise<void> => {
   const context = await contextLazy;
   const {
-    config,
     db,
     nativeMethod,
     network,
     nodeProvider,
-    config: { etherscanApiKey, evmAccount: account },
+    config,
   } = context;
 
   const { asset, id: depositMethodId } = nativeMethod;
+  const { etherscanApiKey, evmAccount: account } = config
 
   const logger = createLogger('ethereum:deposit:confirmed-native');
   const graphQLClient = memGetInternalGqlc();

--- a/confirmed-native-extra.ts
+++ b/confirmed-native-extra.ts
@@ -176,7 +176,7 @@ export const runConfirmedNativeTokenExtraWorker = async (): Promise<void> => {
       txs = txs.filter(tx => ethers.BigNumber.from(tx.value).gt(0));
 
       // Only transactions occuring on or after the order was created
-      txs = txs.filter(tx => new Date(+tx.timestamp * 1000).getTime() >= order.createdAt.getTime());
+      txs = txs.filter(tx => new Date(ns.times(tx.timestamp, "1000")).getTime() >= order.createdAt.getTime());
 
       // Only the first 10 transactions
       txs = txs.slice(0, 10);

--- a/confirmed-native-extra.ts
+++ b/confirmed-native-extra.ts
@@ -25,6 +25,7 @@ const accountTxListResultSchema = z.array(
     from: z.string(),
     to: z.string(),
     value: z.string(),
+    timeStamp: z.string()
   })
 );
 
@@ -174,6 +175,9 @@ export const runConfirmedNativeTokenExtraWorker = async (): Promise<void> => {
       // Only transactions with a value
       txs = txs.filter(tx => ethers.BigNumber.from(tx.value).gt(0));
 
+      // Only transactions occuring on or after the order was created
+      txs = txs.filter(tx => new Date(+tx.timestamp * 1000).getTime() >= order.createdAt.getTime());
+
       // Only the first 10 transactions
       txs = txs.slice(0, 10);
 
@@ -190,26 +194,9 @@ export const runConfirmedNativeTokenExtraWorker = async (): Promise<void> => {
 
         if (!ethersTx.blockNumber) {
           logger.warn('Transaction %s has no block number', etherscanTx.hash);
-
           return;
         }
-
-        const block = await nodeProvider.getBlock(ethersTx.blockNumber);
-
-        const timestamp = new Date(block.timestamp * 1000);
-
-        // Only transactions that happened after the order was created
-        // This should handle deposit address re-assignment
-        if (timestamp.getTime() < order.createdAt.getTime()) {
-          logger.warn(
-            'Ignoring tx %s that happened before order %s was created',
-            etherscanTx.hash,
-            orderId
-          );
-
-          return;
-        }
-
+      
         logger.info('Scanning tx %s', etherscanTx.hash);
 
         await scanTxid(ethersTx);

--- a/descision-record.md
+++ b/descision-record.md
@@ -1,5 +1,10 @@
 ### Time filter inneficiency
 
+__perf: Optimize runScanByOrderId with timestamp param:__
 Checking the [api docs](https://docs.etherscan.io/api-endpoints/accounts#get-a-list-of-normal-transactions-by-address) showed that our account request in `getEtherScanTxListForAddress` has a timestamp paramater available. 
 So we can grab that value from our request instead of having to first grab the block from the `nodeProvider` -> compute time from the block timeStamp. 
 This also allows us to filter our transactions by time earlier, which will reduce the number of txs we promise map through later, less times to getTransaction from the nodeProvider `await nodeProvider.getTransaction(etherscanTx.hash);`
+
+__refactor: use ns wrapper for big number string operations__
+I see that scanTxid uses ns.times() for a bignumber operation between strings, since the received timestamp from etherscan is a big number it's likely safer to use this util.
+In the previous commit I used + to convert from a string to a number before multiplication, this is also not too safe since passing an invalid number would return `NaN`

--- a/descision-record.md
+++ b/descision-record.md
@@ -8,3 +8,7 @@ This also allows us to filter our transactions by time earlier, which will reduc
 __refactor: use ns wrapper for big number string operations__
 I see that scanTxid uses ns.times() for a bignumber operation between strings, since the received timestamp from etherscan is a big number it's likely safer to use this util.
 In the previous commit I used + to convert from a string to a number before multiplication, this is also not too safe since passing an invalid number would return `NaN`
+
+__refactor: remove unused import__
+Config was imported twice and wasn't following the same destructure standard as `nativeMethod`.
+Whilst this is not a performance improvement per say, readable code increases the efficiency of future devs.

--- a/descision-record.md
+++ b/descision-record.md
@@ -1,0 +1,5 @@
+### Time filter inneficiency
+
+Checking the [api docs](https://docs.etherscan.io/api-endpoints/accounts#get-a-list-of-normal-transactions-by-address) showed that our account request in `getEtherScanTxListForAddress` has a timestamp paramater available. 
+So we can grab that value from our request instead of having to first grab the block from the `nodeProvider` -> compute time from the block timeStamp. 
+This also allows us to filter our transactions by time earlier, which will reduce the number of txs we promise map through later, less times to getTransaction from the nodeProvider `await nodeProvider.getTransaction(etherscanTx.hash);`


### PR DESCRIPTION
PR dedicated to finding the main inefficiency in the use of the etherscan api as described in `task.md`

### Context

> `confirm-native-extra.ts` contains a worker that checks specific Ethereum deposit addresses for missed deposits. In the rare event that user deposits are not automatically detected, admins can queue an order for scanning. 
> 
> These `orderId`s are added to a Redis messaging queue through GraphQL and this worker watches these messages, see `const queue = await RedisTaskQueue.queues.evmNativeConfirm(network, true);`
> 
> This code is inefficient and needs to be refactored. To find the inefficiency look at Etherscan API documentation. You can register to Etherscan for a free API key to test it yourself.
> 
> Your task is to refactor this worker and explain how your changes make this worker more efficient. You can write the explanation as comments in the code or as a new `.md` file.


### Changes
- Added a decision record describing the changes, decisions are contained within their respective commits
- Optimised use of timestamp param, filtering the list of transactions earlier, reducing number of nodeProvider awaits required. 